### PR TITLE
Composer Autoloading & Class Name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+composer.lock
 log.txt
 
-docs
-report
+.idea/
+docs/
+report/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ php:
   - "5.4"
   - "5.3"
 
-script: phpunit --bootstrap tests/bootstrap.php tests
+script: php vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,8 @@ php:
   - "5.4"
   - "5.3"
 
+before_script:
+  - curl -s http://getcomposer.org/installer | php
+  - php composer.phar install --dev
+
 script: php vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - "5.3"
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - composer install --dev
 
 script: php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,17 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8"
+    },
     "autoload": {
         "psr-4": {
-            "markroland\\Emma\\": "src/"
+            "MarkRoland\\Emma\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MarkRoland\\Emma\\Tests": "tests/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "MarkRoland\\Emma\\Tests": "tests/"
+            "MarkRoland\\Emma\\Tests\\": "tests/"
         }
     }
 }

--- a/examples/fields.php
+++ b/examples/fields.php
@@ -1,36 +1,35 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // List Fields
-$response = $E->get_field_list(1);
+$response = $client->get_field_list(1);
 
 // Get specific Field
-//$response = $E->get_field(12345);
+//$response = $client->get_field(12345);
 
 // Create new Field
-//$response = $E->create_field('test_field','Test Field','text',3);
+//$response = $client->create_field('test_field','Test Field','text',3);
 
 // Delete Field
-//$response = $E->delete_field(12345);
+//$response = $client->delete_field(12345);
 
 // Clear Field Data
-//$response = $E->clear_member_field_data(12345);
+//$response = $client->clear_member_field_data(12345);
 
 // Update Field
 //$field_data = array('test_field' => 'Test Field Update');
-//$response = $E->update_field(12345, $field_data);
+//$response = $client->update_field(12345, $field_data);
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/groups.php
+++ b/examples/groups.php
@@ -1,58 +1,57 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // List Groups
-$response = $E->list_groups();
+$response = $client->list_groups();
 
 // Create Groups
 //$groups = array( 'groups' => array( array('group_name' => 'Test 1'), array('group_name' => 'Test 2') ) );
 //$groups = array( 'groups' => array( array('group_name' => 'Webhook Test') ) );
-//$response = $E->create_groups($groups);
+//$response = $client->create_groups($groups);
 
 // List Groups
-//$response = $E->list_groups('g,t');
+//$response = $client->list_groups('g,t');
 
 // Get Group Detail
-//$response = $E->get_group_detail(123456);
+//$response = $client->get_group_detail(123456);
 
 // Update Group
-//$response = $E->update_group(123456, 'New Name');
+//$response = $client->update_group(123456, 'New Name');
 
 // Delete Group
-//$response = $E->delete_group(123456);
+//$response = $client->delete_group(123456);
 
 // List Group members
-//$response = $E->list_group_members(123456);
+//$response = $client->list_group_members(123456);
 
 // Add Members to a Group
 //$members = array(123456789,234567890);
-//$response = $E->add_members_to_group(123456,$members);
+//$response = $client->add_members_to_group(123456,$members);
 
 // Remove Members from a Group
 //$members = array(123456789);
-//$response = $E->remove_members_from_group(123456,$members);
+//$response = $client->remove_members_from_group(123456,$members);
 
 // Remove ALL Members from a Group
-//$response = $E->remove_all_members_from_group(123456);
+//$response = $client->remove_all_members_from_group(123456);
 
 // Remove ALL Members from ALL Groups
-//$response = $E->remove_all_members_from_all_groups(123456,'a');
+//$response = $client->remove_all_members_from_all_groups(123456,'a');
 
 // Copy from Group to Group
 //$member_status_id = array('a');
-//$response = $E->copy_group_to_group(123456,654321,$member_status_id);
+//$response = $client->copy_group_to_group(123456,654321,$member_status_id);
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/mailing.php
+++ b/examples/mailing.php
@@ -1,48 +1,47 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // Get mailing List
-$response = $E->get_mailing_list('true','m,t','p,a,s,x,c,f','');
+$response = $client->get_mailing_list('true','m,t','p,a,s,x,c,f','');
 
 // Get mailing detail
-//$response = $E->get_mailing_detail(123456);
+//$response = $client->get_mailing_detail(123456);
 
 // Get mailing members
 // ??? didn't work
-//$response = $E->get_mailing_members(123456);
+//$response = $client->get_mailing_members(123456);
 
 // Get message as sent to member
-//$response = $E->get_mailing_message(123456,123456789);
+//$response = $client->get_mailing_message(123456,123456789);
 
 // Get mailing members
-//$response = $E->get_mailing_groups(123456);
+//$response = $client->get_mailing_groups(123456);
 
 // Update Mailing Status
-//$response = $E->update_mailing_status(123456);
+//$response = $client->update_mailing_status(123456);
 
 // Cancel mailing
-// $response = $E->cancel_mailing(123456);
+// $response = $client->cancel_mailing(123456);
 
 // Forward Message
-//$response = $E->forward_message(123456,123456789,array('recipient@gmail.com'), 'Test Note');
+//$response = $client->forward_message(123456,123456789,array('recipient@gmail.com'), 'Test Note');
 
 // Append Mailing
-//$response = $E->append_to_mailing(123456,'', array('recipient@gmail.com'), array('my-alert@email.com'));
+//$response = $client->append_to_mailing(123456,'', array('recipient@gmail.com'), array('my-alert@email.com'));
 
 // Get Heads up emails
-//$response = $E->get_heads_up_emails(123456);
+//$response = $client->get_heads_up_emails(123456);
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/members.php
+++ b/examples/members.php
@@ -1,94 +1,93 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // List Members
-$response = $E->list_members();
+$response = $client->list_members();
 
 // Count Members
-//$response = $E->list_members(NULL,TRUE);
+//$response = $client->list_members(NULL,TRUE);
 
 // Get Member Info
-//$response = $E->get_member_detail(123456789);
+//$response = $client->get_member_detail(123456789);
 
 // Get Member Info using Email
-//$response = $E->get_member_detail_by_email('recipient@gmail.com');
+//$response = $client->get_member_detail_by_email('recipient@gmail.com');
 
 // Get optout detail
-//$response = $E->get_member_optout_detail(123456789);
+//$response = $client->get_member_optout_detail(123456789);
 
 // Import Members
 //$members = array( array('email'=>'test1@gmail.com'),
 //                  array('email'=>'test2@yahoo.com') );
 //$groups = array(123456,234567);
-//$response = $E->import_member_list($members, 'test-import-2', 1, $groups);
+//$response = $client->import_member_list($members, 'test-import-2', 1, $groups);
 
 // Add/Update Member
 //$fields = array('first_name'=>'Foo', 'last_name'=>'Bar');
 //$groups = '123456';
-//$response = $E->import_single_member('test1@gmail.com', $fields, $groups, $signup_form);
+//$response = $client->import_single_member('test1@gmail.com', $fields, $groups, $signup_form);
 
 // Delete Members
 //$member_ids = array(123456789,234567890);
-//$response = $E->delete_members($member_ids);
+//$response = $client->delete_members($member_ids);
 
 // Update Member Status
 //$member_ids = array(123456789);
-//$response = $E->update_members_status($member_ids, 'e');
+//$response = $client->update_members_status($member_ids, 'e');
 
 // Update Member
 //$fields = array('first_name'=>'Foo', 'last_name'=>'Bar Update');
-//$response = $E->update_member(123456789, 'test1@gmail.com', 'a', $fields);
+//$response = $client->update_member(123456789, 'test1@gmail.com', 'a', $fields);
 
 // Delete Member
-//$response = $E->delete_member(123456789);
+//$response = $client->delete_member(123456789);
 
 // List Member's Groups
-//$response = $E->list_member_groups(123456789);
+//$response = $client->list_member_groups(123456789);
 
 // Add Member to Group(s)
-//$response = $E->add_member_to_groups(123456789, array(123456) );
+//$response = $client->add_member_to_groups(123456789, array(123456) );
 
 // Remove Member from Group(s)
-//$response = $E->remove_member_from_groups(123456789, array(123456) );
+//$response = $client->remove_member_from_groups(123456789, array(123456) );
 
 // Delete all members
-//$response = $E->remove_all_members('e');
+//$response = $client->remove_all_members('e');
 
 // Remove Member from all Groups
-//$response = $E->remove_member_from_all_groups(123456789);
+//$response = $client->remove_member_from_all_groups(123456789);
 
 // Remove Members from all Groups
-//$response = $E->remove_members_from_groups(array(123456789,234567890), array(123456,654321));
+//$response = $client->remove_members_from_groups(array(123456789,234567890), array(123456,654321));
 
 // Get mailing history
-//$response = $E->get_member_mailing_history(123456789);
+//$response = $client->get_member_mailing_history(123456789);
 
 // Get Import stats regarding members
-//$response = $E->get_import_stats_members(567890);
+//$response = $client->get_import_stats_members(567890);
 
 // Get Import stats
-//$response = $E->get_import_stats(567890);
+//$response = $client->get_import_stats(567890);
 
 // Get Import stats for all imports
-//$response = $E->get_all_import_stats();
+//$response = $client->get_all_import_stats();
 
 // Get Import stats for all imports
-//$response = $E->copy_to_group(123456, array('a','e') );
+//$response = $client->copy_to_group(123456, array('a','e') );
 
 // Update the status for a group of members, based on their current status
-//$response = $E->bulk_change_member_status('e','a');
+//$response = $client->bulk_change_member_status('e','a');
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/response.php
+++ b/examples/response.php
@@ -1,72 +1,71 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // Get Response
-$response = $E->get_response();
+$response = $client->get_response();
 
 // Get Response Overview
-//$response = $E->get_response_overview(567890);
+//$response = $client->get_response_overview(567890);
 
 // Get Sends
-//$response = $E->get_sends(567890);
+//$response = $client->get_sends(567890);
 
 // Get In Progress
-//$response = $E->get_in_progress(567890);
+//$response = $client->get_in_progress(567890);
 
 // Get Deliviers
-//$response = $E->get_deliveries(567890);
+//$response = $client->get_deliveries(567890);
 
 // Get Opens
-//$response = $E->get_opens(567890);
+//$response = $client->get_opens(567890);
 
 // Get Links
-//$response = $E->get_links(567890);
+//$response = $client->get_links(567890);
 
 // Get Clicks
-//$response = $E->get_clicks(567890);
-//$response = $E->get_clicks(567890,123456789);
-//$response = $E->get_clicks(567890,123456789,4567890);
+//$response = $client->get_clicks(567890);
+//$response = $client->get_clicks(567890,123456789);
+//$response = $client->get_clicks(567890,123456789,4567890);
 
 // Get Forwards
-//$response = $E->get_forwards(567890);
+//$response = $client->get_forwards(567890);
 
 // Get Optouts
-//$response = $E->get_optouts(567890);
+//$response = $client->get_optouts(567890);
 
 // Get Signups
-//$response = $E->get_signups(567890);
+//$response = $client->get_signups(567890);
 
 // Get Shares
-//$response = $E->get_shares(567890);
+//$response = $client->get_shares(567890);
 
 // Get Shares
 // Didn't work. Must be via Social Publishing (?)
-//$response = $E->save_customer_share(567890);
+//$response = $client->save_customer_share(567890);
 
 // Get Customer Shares
-//$response = $E->get_customer_shares(567890);
+//$response = $client->get_customer_shares(567890);
 
 // Get Customer Share Clicks
-//$response = $E->get_customer_share_clicks(567890);
+//$response = $client->get_customer_share_clicks(567890);
 
 // Get Share Info
 // Untested
-//$response = $E->get_customer_share();
+//$response = $client->get_customer_share();
 
 // Get Share Overview
-//$response = $E->get_share_overview(567890);
+//$response = $client->get_share_overview(567890);
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/searches.php
+++ b/examples/searches.php
@@ -1,39 +1,38 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // List Members
-$response = $E->list_searches();
+$response = $client->list_searches();
 
 // Get Search Details
-//$response = $E->get_search_detail(1234);
+//$response = $client->get_search_detail(1234);
 
 // Create Search
 //$criteria = array( 'and', array('email','contains','gmail.com') );
 //$name = 'Gmail users';
-//$response = $E->create_search($criteria, $name);
+//$response = $client->create_search($criteria, $name);
 
 // Update Search
 //$criteria = array( 'or', array('email','contains','gmail.com'), array('email','eq','test1@yahoo.com') );
 //$name = 'Gmail users and test';
-//$response = $E->update_search(1234,$criteria, $name);
+//$response = $client->update_search(1234,$criteria, $name);
 
 // Get Search Members
-//$response = $E->get_search_members(1234);
+//$response = $client->get_search_members(1234);
 
 // Delete Search
-//$response = $E->delete_search(1234);
+//$response = $client->delete_search(1234);
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/triggers.php
+++ b/examples/triggers.php
@@ -1,35 +1,34 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // List Triggers
-//$response = $E->list_triggers();
+//$response = $client->list_triggers();
 
 // Create Trigger
-//$response = $E->create_trigger('test trigger','s',13579);
+//$response = $client->create_trigger('test trigger','s',13579);
 
 // Get Trigger
-//$response = $E->get_trigger(13579);
+//$response = $client->get_trigger(13579);
 
 // Update Trigger
-//$response = $E->update_trigger(13579);
+//$response = $client->update_trigger(13579);
 
 // Delete Trigger
-//$response = $E->delete_trigger(13579);
+//$response = $client->delete_trigger(13579);
 
 // Get mailings sent by a trigger.
-//$response = $E->get_trigger_mailings(13579);
+//$response = $client->get_trigger_mailings(13579);
 
 // Display response
 var_dump($response);
 
-?>

--- a/examples/webhooks.php
+++ b/examples/webhooks.php
@@ -1,35 +1,34 @@
 <?php
 
 // Include Emma class
-require __DIR__ . '/../src/Emma.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 // Create new Emma class object
-$E = new markroland\Emma('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
+$client = new MarkRoland\Emma\Client('1234567', 'Drivorj7QueckLeuk', 'WoghtepheecijnibV');
 
 // Control Debugging output
-$E->debug = true;
+$client->debug = true;
 
 // Make API request
 
 // List Webhooks
-$response = $E->list_webhooks();
+$response = $client->list_webhooks();
 
 // Get Webhook
-//$response = $E->get_webhook(1234);
+//$response = $client->get_webhook(1234);
 
 // List Webhooks
-//$response = $E->list_webhook_event_types();
+//$response = $client->list_webhook_event_types();
 
 // Create Webhook
-//$response = $E->create_webhook('message_open','https://yourcallbackurl...','POST');
+//$response = $client->create_webhook('message_open','https://yourcallbackurl...','POST');
 
 // Update Webhook
-//$response = $E->update_webhook(1234,'message_forward','https://yourcallbackurl...','POST','your-emma-user-id');
+//$response = $client->update_webhook(1234,'message_forward','https://yourcallbackurl...','POST','your-emma-user-id');
 
 // Delete Webhook
-//$response = $E->delete_webhook(1234);
+//$response = $client->delete_webhook(1234);
 
 // Display response
 var_dump($response);
 
-?>

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Installation
 ------------
 
 ```sh
-    composer require markroland/emma:~2
+    composer require markroland/emma ~2.0
 ```
 
 Usage

--- a/readme.md
+++ b/readme.md
@@ -25,17 +25,31 @@ Usage
 To get started, initialize the Emma class as follows:
 
 ```php
-    $emma = new Emma(<account_id>, <public_key>, <private_key>);
+    use MarkRoland\Emma\Client;
+
+    $emma = new Client(<account_id>, <public_key>, <private_key>);
 ```
 
 For example,
 
 ```php
-    $emma = new Emma('1234','Drivorj7QueckLeuk','WoghtepheecijnibV');
+    use MarkRoland\Emma\Client;
+
+    $emma = new Client('1234','Drivorj7QueckLeuk','WoghtepheecijnibV');
 ```
 
-The "tests" folder in this package contains some test scripts that can
-be run to see how emma.class.php may be used.
+The [tests](https://github.com/markroland/emma/blob/master/tests) folder in this package contains some test scripts that can
+be run to see how Emma Client class may be used.
+
+Also look in the [examples](https://github.com/markroland/emma/blob/master/examples/) folder for code examples for:
+- [fields](https://github.com/markroland/emma/blob/master/examples/fields.php)
+- [groups](https://github.com/markroland/emma/blob/master/examples/groups.php)
+- [mailing](https://github.com/markroland/emma/blob/master/examples/mailing.php)
+- [members](https://github.com/markroland/emma/blob/master/examples/members.php)
+- [response](https://github.com/markroland/emma/blob/master/examples/response.php)
+- [searches](https://github.com/markroland/emma/blob/master/examples/searches.php)
+- [triggers](https://github.com/markroland/emma/blob/master/examples/triggers.php)
+- [webhooks](https://github.com/markroland/emma/blob/master/examples/webhooks.php)
 
 In order to understand how to use this script, please make sure you
 have a good understanding of the Emma API:

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace markroland;
+namespace MarkRoland\Emma;
+
+use Exception;
 
 /**
  * Emma Class
@@ -12,9 +14,8 @@ namespace markroland;
  *
  * Documentation: http://api.myemma.com/
  **/
-class Emma
+class Client
 {
-
     /**
      * Emma API Dommain
      * @var string
@@ -90,11 +91,11 @@ class Emma
      * @param  string|array $account_id  The Emma Account ID on which to perform actions, or an array of params
      * @param  string       $public_key  The Emma public key for the account
      * @param  string       $private_key The Emma private key for the account
-     * @return boolean false if $account_id is not provided
-     **/
+     *
+     * @throws Exception
+     */
     function __construct($account_id, $public_key=null, $private_key=null)
     {
-
         if (is_array($account_id) ) {
             $params = $account_id;
             $account_id = isset($params['account_id']) ? $params['account_id'] : null;
@@ -103,14 +104,13 @@ class Emma
         }
 
         if (empty($account_id) || empty($public_key) || empty($private_key) ) {
-            throw new \Exception('Emma Error: no account id, public key, or private key sent to constructor.');
+            throw new Exception('Emma Error: no account id, public key, or private key sent to constructor.');
         }
 
         // Save account ID to class object variable
         $this->emma_account_id = $account_id;
         $this->emma_public_key = $public_key;
         $this->emma_private_key = $private_key;
-
     }
 
     /**
@@ -1630,4 +1630,3 @@ class Emma
     /* *** END `WEBHOOKS` METHODS *** */
 
 } // END class
-?>

--- a/src/Client.php
+++ b/src/Client.php
@@ -579,7 +579,7 @@ class Client
      **/
     function get_mailing_groups($mailing_id)
     {
-        $data = $this->make_request('mailings/'.$mailing_id.'/groups'.$member_id, 'GET');
+        $data = $this->make_request('mailings/'.$mailing_id.'/groups'.$mailing_id, 'GET');
         return $data;
     }
 
@@ -1305,7 +1305,7 @@ class Client
      **/
     function get_customer_share($share_id)
     {
-        $data = $this->make_request('response/'.$mailing_id.'/customer_share', 'GET');
+        $data = $this->make_request('response/'.$share_id.'/customer_share', 'GET');
         return $data;
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1416,6 +1416,8 @@ class Client
     /* *** BEGIN `TRIGGERS` METHODS *** */
 
     /**
+     * @deprecated
+     *
      * Get a basic listing of all triggers in an account.
      *
      * @param  boolean $deleted Set to TRUE or 1 to include deleted fields in results
@@ -1428,6 +1430,8 @@ class Client
     }
 
     /**
+     * @deprecated
+     *
      * Create a new trigger.
      *
      * @param  string  $name              A descriptive name for the trigger.
@@ -1475,6 +1479,8 @@ class Client
     }
 
     /**
+     * @deprecated
+     *
      * Look up a trigger by trigger id.
      *
      * @param  string $trigger_id A unique Trigger ID
@@ -1487,6 +1493,8 @@ class Client
     }
 
     /**
+     * @deprecated
+     *
      * Update or edit a trigger.
      *
      * @param  string $trigger_id A unique Trigger ID
@@ -1499,6 +1507,8 @@ class Client
     }
 
     /**
+     * @deprecated
+     *
      * Delete a trigger.
      *
      * @param  string $trigger_id A unique Trigger ID
@@ -1511,6 +1521,8 @@ class Client
     }
 
     /**
+     * @deprecated
+     *
      * Get mailings sent by a trigger.
      *
      * @param  string $trigger_id A unique Trigger ID

--- a/tests/EmmaTest.php
+++ b/tests/EmmaTest.php
@@ -1,20 +1,44 @@
 <?php
 
-class EmmaTest extends PHPUnit_Framework_TestCase {
+namespace MarkRoland\Emma\Tests;
 
-    protected $EmmaClient;
+use MarkRoland\Emma\Client;
+use PHPUnit_Framework_TestCase;
 
-    public function setup() {
+class EmmaTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Client
+     */
+    protected $emmaClient;
+    /**
+     * @var int
+     */
+    protected $accountId = 123456;
+    /**
+     * @var string
+     */
+    protected $publicKey = 'XXXXXXXXXXXXXXXXXXXX';
+    /**
+     * @var string
+     */
+    protected $privateKey = 'XXXXXXXXXXXXXXXXXXXX';
 
-        $this->EmmaClient = new markroland\Emma(
-            EMMA_ACCOUNT_ID,
-            EMMA_PUBLIC_KEY,
-            EMMA_PRIVATE_KEY
-        );
+    /**
+     * Setup Emma Client
+     */
+    public function setup()
+    {
+        $this->emmaClient = new Client($this->accountId, $this->publicKey, $this->privateKey);
     }
 
-    public function test_get_field_list() {
-        $response = $this->EmmaClient->get_field_list(1);
+    /**
+     * @test
+     */
+    public function test_get_field_list()
+    {
+        $response = $this->emmaClient->get_field_list(1);
+
         $this->assertNull($response);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,5 @@
 <?php
 
-define('EMMA_ACCOUNT_ID', '123456');
-define('EMMA_PUBLIC_KEY', 'XXXXXXXXXXXXXXXXXXXX');
-define('EMMA_PRIVATE_KEY', 'XXXXXXXXXXXXXXXXXXXX');
+require dirname(__DIR__).'/vendor/autoload.php';
 
-require __DIR__ . '/../src/Emma.php';
+date_default_timezone_set('UTC');


### PR DESCRIPTION
## What this did
Sturdy case markroland when referencing the namespace (e.g. `MarkRoland`).

The composer.json file sets the src folder to be namespaced as `MarkRoland\Emma`, but the Emma (Client) class only referenced MarkRoland (`markroland`).
The Emma (Client) class should be under the same namespace as in the composer.json, this is now so.

Renamed the Emma class to Client, making the reference to the class less redundant (otherwise `MarkRoland\Emma\Emma`) and more descriptive (`MarkRoland\Emma\Client`).

Updating tests, autoload-dev the tests and namespace them under `MarkRoland\Emma\Tests` and adding phpunit ~4.8 under require-dev in composer.json.
Updating travis to use `vendor/bin/phpunit` for running unit tests. Updating bootstrap to use autoload.php instead of the Emma (Client) class directly.

Updating all php files in examples folder to reference the Emma (Client) class correctly and use the autoload.php file.

Removing all closing php tags ?> in all files, this has become optional and is not recommended.

Updating the readme file with reference to new class name `Client` and adding note about the examples folder.

**Issue:** https://github.com/markroland/emma/issues/5